### PR TITLE
Remove trailing slash from baseUrl in examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ import { HttpClient, Api } from 'tonapi-sdk-js';
 
 // Configure the HTTP client with your host and token
 const httpClient = new HttpClient({
-    baseUrl: 'https://tonapi.io/',
+    baseUrl: 'https://tonapi.io',
     baseApiParams: {
         headers: {
             Authorization: `Bearer ${YOUR_TOKEN}`,

--- a/migration.md
+++ b/migration.md
@@ -50,7 +50,7 @@ In **v1**, you now only need to create a single instance of the API:
 import { HttpClient, Api } from 'tonapi-sdk-js';
 
 const httpClient = new HttpClient({
-    baseUrl: 'https://tonapi.io/',
+    baseUrl: 'https://tonapi.io',
     baseApiParams: {
         headers: {
             Authorization: `Bearer ${YOUR_TOKEN}`,


### PR DESCRIPTION
The trailing slash in the baseUrl of the examples is unnecessary and can lead to unexpected behavior. This PR removes the trailing slash from the baseUrl in the examples in the README.md and migration.md files.

This is a quality of life improvement for users of the SDK, which copy the example and API seems to be working as expected, until they try to make a POST request.

Note: double slash issue could also be handled on the server side, by returning a different code - [`308 Permanent Redirect`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/308), where the request method and the body will not be altered.

## Cause

While the trailing slash in the baseUrl doesn't cause issues for GET requests, it breaks POST requests. Since resulting endpoint will have double slashes (e.g. https://tonapi.io//v2/nfts/_bulk), it leads to a `301 Moved Permanently` response from the server, which changes the POST request to a GET request, which results in server returning error.

### How to reproduce

Returns correct response:

```bash
curl -vL -X 'POST' \
  'https://tonapi.io/v2/nfts/_bulk' \
  -H 'accept: application/json' \
  -H 'Content-Type: application/json' \
  -d '{
  "account_ids": [
    "0:1c5986ae4263a34e7eb44e41d2a9e6aa9ee5861a1a847fc7b064688bdfb2c183"
  ]
}'
```

Returns `301 Moved Permanently`, redirects as GET and results in error:
```bash
curl -vL -X 'POST' \
  'https://tonapi.io//v2/nfts/_bulk' \
  -H 'accept: application/json' \
  -H 'Content-Type: application/json' \
  -d '{
  "account_ids": [
    "0:1c5986ae4263a34e7eb44e41d2a9e6aa9ee5861a1a847fc7b064688bdfb2c183"
  ]
}'
```
